### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "foogile/wp-cli-mig",
     "description": "General migration command for WP-CLI",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/stianlik/wp-cli-mig/",
     "authors": [
         {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
